### PR TITLE
Update Package Name, Fix Dependency Versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-email=${ESSEX_EMAIL}
-registry=http://essex-private-npm.westus.cloudapp.azure.com:4873/
-//essex-private-npm.westus.cloudapp.azure.com:4873/:_authToken="${ESSEX_NPM_TOKEN}"

--- a/example/state/reducers/index.ts
+++ b/example/state/reducers/index.ts
@@ -1,6 +1,6 @@
 import * as redux from 'redux';
-import dagHistory from 'redux-dag-history/lib/reducer';
-import Configuration from 'redux-dag-history/lib/Configuration';
+import dagHistory from '@essex/redux-dag-history/lib/reducer';
+import Configuration from '@essex/redux-dag-history/lib/Configuration';
 import app from './app';
 import history from '../../../src/reducer';
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dag-history-component",
+  "name": "@essex/dag-history-component",
   "version": "0.5.0",
   "description": "A React Component for Dag-History Visualization",
   "main": "lib/index.js",
@@ -65,6 +65,7 @@
     "mocha-multi": "^0.9.1",
     "node-sass": "^4.0.0",
     "npm-run-all": "^3.1.0",
+    "nyc": "^10.0.0",
     "postcss-loader": "^1.0.0",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.4.1",
@@ -78,6 +79,8 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^1.2.2",
     "ts-node": "^1.7.0",
+    "typescript": "^2.1.4",
+    "typescript-eslint-parser": "^1.0.0",
     "wallaby-webpack": "0.0.23",
     "webpack": "^1.13.1",
     "webpack-dev-middleware": "^1.6.1",
@@ -85,6 +88,7 @@
     "webpack-hot-middleware": "^2.12.0"
   },
   "dependencies": {
+    "@essex/redux-dag-history": "^1.6.0",
     "@types/classnames": "^0.0.32",
     "@types/node": "^6.0.51",
     "@types/react": "^0.14.51",
@@ -95,7 +99,6 @@
     "classnames": "^2.2.5",
     "debug": "^2.2.0",
     "lodash": "^4.17.2",
-    "nyc": "^10.0.0",
     "react": "^15.4.1",
     "react-icons": "^2.2.1",
     "react-keydown": "^1.6.2",
@@ -103,10 +106,7 @@
     "react-simple-dropdown": "^1.1.4",
     "react-tabs": "^0.7.0",
     "redux": "^3.3.1",
-    "redux-actions": "^0.12.0",
-    "redux-dag-history": "^1.6.0",
-    "typescript": "2.1.3-insiders.20161130",
-    "typescript-eslint-parser": "^1.0.0"
+    "redux-actions": "^0.12.0"
   },
   "nyc": {
     "include": [

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,6 @@
-import { StateId } from 'redux-dag-history/lib/interfaces';
+import { StateId } from '@essex/redux-dag-history/lib/interfaces';
 import * as Actions from 'redux-actions';
-import { jumpToState } from 'redux-dag-history/lib/ActionCreators';
+import { jumpToState } from '@essex/redux-dag-history/lib/ActionCreators';
 
 // Action Types
 export const SELECT_MAIN_VIEW = 'SELECT_MAIN_VIEW';

--- a/src/components/BookmarkList/index.tsx
+++ b/src/components/BookmarkList/index.tsx
@@ -4,7 +4,7 @@ import './BookmarkList.scss';
 
 const { PropTypes } = React;
 
-const log = require('debug')('redux-dag-history:BookmarkList');
+const log = require('debug')('@essex/redux-dag-history:BookmarkList');
 
 const placeholder = document.createElement('div');
 placeholder.className = 'placeholder';

--- a/src/components/History/BookmarkActions.ts
+++ b/src/components/History/BookmarkActions.ts
@@ -1,4 +1,4 @@
-import DagGraph from 'redux-dag-history/lib/DagGraph';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
 import { determineCommitPathLength } from '../provenance';
 
 export default function makeActions(

--- a/src/components/History/HistoryView/BranchListContainer.tsx
+++ b/src/components/History/HistoryView/BranchListContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import DagGraph from 'redux-dag-history/lib/DagGraph';
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
 import BranchList from '../../BranchList';
 import isNumber from '../../../isNumber';
 

--- a/src/components/History/HistoryView/BranchedHistoryView.tsx
+++ b/src/components/History/HistoryView/BranchedHistoryView.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
-import * as DagHistoryActions from 'redux-dag-history/lib/ActionCreators';
+import * as DagHistoryActions from '@essex/redux-dag-history/lib/ActionCreators';
 import * as DagComponentActions from '../../../actions';
 import ExpandCollapseToggle from '../../ExpandCollapseToggle';
 import Transport from '../../Transport';

--- a/src/components/History/HistoryView/ChronologicalHistoryView.tsx
+++ b/src/components/History/HistoryView/ChronologicalHistoryView.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as DagHistoryActions from 'redux-dag-history/lib/ActionCreators';
+import * as DagHistoryActions from '@essex/redux-dag-history/lib/ActionCreators';
 import StateListContainer from './StateListContainer';
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";

--- a/src/components/History/HistoryView/StateListContainer.tsx
+++ b/src/components/History/HistoryView/StateListContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import DagGraph from 'redux-dag-history/lib/DagGraph';
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
 import StateList from '../../StateList';
 import isNumber from '../../../isNumber';
 

--- a/src/components/History/StoryboardingView/BookmarkListContainer.tsx
+++ b/src/components/History/StoryboardingView/BookmarkListContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import DagGraph from 'redux-dag-history/lib/DagGraph';
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
-import * as DagHistoryActions from 'redux-dag-history/lib/ActionCreators';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
+import * as DagHistoryActions from '@essex/redux-dag-history/lib/ActionCreators';
 import * as Actions from '../../../actions';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/src/components/History/StoryboardingView/index.tsx
+++ b/src/components/History/StoryboardingView/index.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import * as DagHistoryActions from 'redux-dag-history/lib/ActionCreators';
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
+import * as DagHistoryActions from '@essex/redux-dag-history/lib/ActionCreators';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
 import { connect } from 'react-redux';
-import DagGraph from 'redux-dag-history/lib/DagGraph';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
 import { bindActionCreators } from "redux";
 import Transport from '../../Transport';
 import * as Actions from '../../../actions';

--- a/src/components/History/index.tsx
+++ b/src/components/History/index.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import * as DagHistoryActions from 'redux-dag-history/lib/ActionCreators';
+import * as DagHistoryActions from '@essex/redux-dag-history/lib/ActionCreators';
 import * as Actions from '../../actions';
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
-import DagGraph from 'redux-dag-history/lib/DagGraph';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
+import DagGraph from '@essex/redux-dag-history/lib/DagGraph';
 import * as DagComponentActions from '../../actions';
 import HistoryTabs from './HistoryTabs';
 import Transport from '../Transport';

--- a/src/components/History/interfaces.ts
+++ b/src/components/History/interfaces.ts
@@ -1,4 +1,4 @@
-import { IDagHistory } from 'redux-dag-history/lib/interfaces';
+import { IDagHistory } from '@essex/redux-dag-history/lib/interfaces';
 
 export interface IHistoryContainerSharedProps {
   history: IDagHistory<any>;

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,6 +1,6 @@
 import {
   IConfiguration, // eslint-disable-line no-unused-vars
-} from 'redux-dag-history/lib/interfaces';
+} from '@essex/redux-dag-history/lib/interfaces';
 import {
   SELECT_MAIN_VIEW,
   SELECT_HISTORY_TYPE,

--- a/test/components/History/index.spec.tsx
+++ b/test/components/History/index.spec.tsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import * as Promise from 'bluebird';
-import * as dagHistory from 'redux-dag-history/lib/DagHistory';
+import * as dagHistory from '@essex/redux-dag-history/lib/DagHistory';
 import History from '../../../src/components/History';
 
 import { createStore } from 'redux';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@essex/redux-dag-history@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@essex/redux-dag-history/-/redux-dag-history-1.6.0.tgz#099adff355e11989047516cd96a347c88bc9ba24"
+  dependencies:
+    "@types/redux-actions" "^0.8.30"
+    debug "^2.2.0"
+    immutable "^3.8.1"
+    redux-actions "^0.10.0"
+    treeify "^1.0.1"
+
 "@kadira/react-split-pane@^1.4.0":
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/@kadira/react-split-pane/-/react-split-pane-1.4.7.tgz#6d753d4a9fe62fe82056e323a6bcef7f026972b5"
@@ -5022,11 +5032,10 @@ readable-stream@^1.0.27-1, readable-stream@^1.1.13, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@^2.0.0 || ^1.1.13", readable-stream@~2.1.4:
-  version "2.1.5"
-  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
+"readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
-    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
@@ -5034,10 +5043,11 @@ readable-stream@^1.0.27-1, readable-stream@^1.1.13, readable-stream@~1.1.9:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+readable-stream@~2.1.4:
+  version "2.1.5"
+  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
   dependencies:
+    buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
@@ -5114,16 +5124,6 @@ redux-actions@^0.12.0:
   dependencies:
     lodash "^4.13.1"
     reduce-reducers "^0.1.0"
-
-redux-dag-history@^1.6.0:
-  version "1.6.0"
-  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/redux-dag-history/-/redux-dag-history-1.6.0.tgz#99a3e74008174dbb8511a26c8ba79990a55f22d0"
-  dependencies:
-    "@types/redux-actions" "^0.8.30"
-    debug "^2.2.0"
-    immutable "^3.8.1"
-    redux-actions "^0.10.0"
-    treeify "^1.0.1"
 
 redux-logger@^2.6.1:
   version "2.7.4"
@@ -5895,9 +5895,9 @@ typescript-eslint-parser@^1.0.0:
     lodash.unescape "4.0.0"
     object-assign "^4.0.1"
 
-typescript@2.1.3-insiders.20161130:
-  version "2.1.3-insiders.20161130"
-  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/typescript/-/typescript-2.1.3-insiders.20161130.tgz#551668ba383827bdf4033aa99c6c4c3f0bd80cec"
+typescript@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.4.tgz#b53b69fb841126acb1dd4b397d21daba87572251"
 
 ua-parser-js@^0.7.9:
   version "0.7.12"


### PR DESCRIPTION
* Update the package to be scoped under the essex npm user. 
* Some development dependencies creeped into the main 'dependencies' section. Putting them back where they belong.
* Updating usage of 'redux-dag-history' to point at the new scoped package name.